### PR TITLE
catch error when importing MeanUCERF3 and added alternative

### DIFF
--- a/FetchOpenSHA.py
+++ b/FetchOpenSHA.py
@@ -73,7 +73,10 @@ from org.opensha.sha.imr.param.OtherParams import *
 from org.opensha.sha.imr.param.SiteParams import Vs30_Param
 from org.opensha.sha.calc import *
 from org.opensha.sha.util import *
-from scratch.UCERF3.erf.mean import MeanUCERF3
+try:
+    from scratch.UCERF3.erf.mean import MeanUCERF3
+except ModuleNotFoundError:
+    MeanUCERF3 = jpype.JClass("scratch.UCERF3.erf.mean.MeanUCERF3")
 
 from org.opensha.sha.gcim.imr.attenRelImpl import *
 from org.opensha.sha.gcim.imr.param.IntensityMeasureParams import *


### PR DESCRIPTION
- added a catch for module error when importing MeanUCERF3 from OpenSHA-UCERF3
- added alternative import method via jpype.JClass